### PR TITLE
Enable debugging notebook code in the notebook file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 Manifest.toml
-
 docs/build/
+test*.jl

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,17 @@ version = "0.2.0"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"
+ExpressionExplorer = "21656369-7473-754a-2065-74616d696c43"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
 AbstractPlutoDingetjes = "1.2"
+ExpressionExplorer = "1"
+InteractiveUtils = "1.9"
+Markdown = "1.9"
+REPL = "1.9"
 julia = "1.9"
 
 [extras]

--- a/src/PlutoVSCodeDebugger.jl
+++ b/src/PlutoVSCodeDebugger.jl
@@ -4,6 +4,8 @@ using AbstractPlutoDingetjes
 import REPL
 import Markdown
 import InteractiveUtils
+using ExpressionExplorer
+using ExpressionExplorer: is_function_assignment, explore_funcdef!, canonalize, ScopeState
 
 export @run, @enter, @connect_vscode, @vscedit, @bp, @breakpoint
 
@@ -17,6 +19,7 @@ include("basics.jl")
 include("file_locations.jl")
 include("debugger.jl")
 include("macros.jl")
+include("additional_stuff.jl")
 
 # This module just re-export the main module plus the debgging functions of JuliaInterpreter
 module WithFunctions

--- a/src/additional_stuff.jl
+++ b/src/additional_stuff.jl
@@ -1,0 +1,149 @@
+const _cell_id_delimiter = "# ╔═╡ "
+const _proj_uuid = Base.UUID(1)
+const _manifest_uuid = Base.UUID(2)
+
+function parse_notebook_cells(file)
+    open(file) do io
+        nlines = 1
+        out = Tuple{Base.UUID, Int, String}[] 
+        # Drop the preamble
+        preamble = readuntil(io, _cell_id_delimiter)
+        nlines += count('\n', preamble)
+        while !eof(io)
+            parsed_id = readline(io) |> String
+            startswith(parsed_id, "Cell order") && break
+            cell_uuid = Base.UUID(parsed_id)
+            (cell_uuid === _proj_uuid || cell_uuid === _manifest_uuid) && break
+            parsed_code = readuntil(io, _cell_id_delimiter)
+            push!(out, (cell_uuid, nlines, parsed_code))
+            nlines += count('\n', parsed_code) + 1 # +1 is for the line of the cell uuid
+        end
+        out
+    end
+end
+
+# Store the list of struct definition and an array of Expr defining methods
+@kwdef struct NotebookDefinitions
+    structdefs::Set{Symbol} = Set{Symbol}()
+    funcdefexprs::Vector{Expr} = Expr[]
+end
+
+modify_lnn(lnn::LineNumberNode; file, start_line) = LineNumberNode(lnn.line + start_line, file)
+function  modify_lnn!(expr::Expr; file, start_line)
+    for i in eachindex(expr.args)
+        arg = expr.args[i]
+        if arg isa LineNumberNode
+            expr.args[i] = modify_lnn(arg; file, start_line)
+        elseif arg isa Expr
+            modify_lnn!(arg; file, start_line)
+        end
+    end
+end
+
+is_toplevel_funcdef(::FunctionName{N}) where N = N == 1
+# This function filters away 
+function filter_fnsigs(rn::ReactiveNode, nd::NotebookDefinitions)
+    sd = nd.structdefs
+    fs = rn.funcdefs_with_signatures
+    filter(fs) do (;name)
+        is_toplevel_funcdef(name) || return false
+        name.joined ∉ sd
+    end
+end
+
+function extract_funcdefs!(nd::NotebookDefinitions, fnsigs, ex; ss = ScopeState())
+    ex isa Expr || return
+    if is_function_assignment(ex)
+        funcroot = ex.args[1]
+        funcname, _ = explore_funcdef!(funcroot, ss)
+        fnsig = FunctionNameSignaturePair(funcname, hash(canonalize(funcroot)))
+        fnsig ∈ fnsigs || return
+        delete!(fnsigs, fnsig)
+        push!(nd.funcdefexprs, ex)
+    else
+        for arg in ex.args
+            isempty(fnsigs) && return
+            extract_funcdefs!(nd, fnsigs, arg; ss)
+        end
+    end
+end
+
+function process_expanded_expr!(crn::ReactiveNode, notebookdefs::NotebookDefinitions, ex; start_line, caller_data)
+    (;filename) = caller_data
+    rn = compute_reactive_node(ex)
+    # We merge this rn with the compound rn of the notebook
+    union!(crn, rn)
+    # Find new struct definition, which should have both a method and a definition in the reactive node
+    structdefs = intersect(rn.definitions, rn.funcdefs_without_signatures)
+    # We add to the stored structdefs
+    union!(notebookdefs.structdefs, structdefs)
+    # We find the valid function signatures
+    fnsigs = filter_fnsigs(rn, notebookdefs)
+    !isempty(fnsigs) || return
+    # Put the non-pluto line node in this expression
+    modify_lnn!(ex; file = filename, start_line)
+    extract_funcdefs!(notebookdefs, fnsigs, ex)
+    return 
+end
+
+function get_modexp(cells_data, caller_data)
+    (;pluto_module, cell_uuid) = caller_data
+    nd = NotebookDefinitions()
+    rn = ReactiveNode()
+    for (uuid, start_line, code) in cells_data
+        uuid === cell_uuid && break
+        eex = Main.PlutoRunner.cell_expanded_exprs[uuid].expanded_expr
+        @assert length(eex.args) == 1 && Meta.isexpr(eex.args[1], :block) "The cached expanded exprs should always have a begin end block inside the quote"
+        ex = eex.args[1] |> deepcopy
+        process_expanded_expr!(rn, nd, ex; start_line, caller_data)
+    end
+    modex = :(module _NotebookCode_ end)
+    toplevel_args = modex.args[end].args
+    import_ex = let
+        modname_ex = Expr(:., :Main, nameof(pluto_module))
+        names_to_import = filter(rn.references) do name
+            name ∉ (:eval, :Main) || return false
+            contains(String(name), ".") && return false
+            name ∈ rn.funcdefs_without_signatures && return false
+            return true
+        end |> Tuple
+        names_exs = map(names_to_import) do name
+            Expr(:., name)
+        end
+        ex = Expr(:(:), modname_ex, names_exs...)
+        Expr(:import, ex)
+    end
+    push!(toplevel_args, import_ex)
+    append!(toplevel_args, nd.funcdefexprs)
+    modex
+end
+
+struct ASD
+    b::Int
+end
+
+function notebook_code_module(pluto_file_symbol, pluto_module; eval = true)
+    filename, cell_uuid = try
+        split(String(pluto_file_symbol), "#==#")
+    catch e
+        @error "It seems you are calling this macro from outside Pluto, which is not supported"
+        rethrow()
+    end
+    filename = String(filename)
+    cell_uuid = Base.UUID(cell_uuid)
+    file_symbol = Symbol(filename)
+    caller_data = (;
+        pluto_module,
+        cell_uuid,
+        pluto_file_symbol,
+        filename,
+        file_symbol
+    )
+    cells_data = parse_notebook_cells(filename)
+    modex = get_modexp(cells_data, caller_data)
+    # We now evaluate this expression in Main
+    if eval
+        Core.eval(Main, modex)
+    end
+    modex
+end

--- a/src/debugger.jl
+++ b/src/debugger.jl
@@ -53,6 +53,8 @@ function remove_lln!(ex::Expr)
 end
 
 function process_expr(command, _mod, _file)
+    # 
+    notebook_code_module(_file, _mod; eval = true)
     remove_lln!(command)
     try_replace_macros!(command; _mod, _file)
     _names = Set{Symbol}()
@@ -61,13 +63,14 @@ function process_expr(command, _mod, _file)
         command
     else
         :(let 
-            (;$(_names...)) = $_mod
+            (;$(_names...)) = Main._NotebookCode_
             $command
         end)
     end
     remove_lln!(code)
     code
 end
+
 
 function send_to_debugger(method; code, filename)
     VSCodeServer = get_vscode()


### PR DESCRIPTION
This PR adds the capability of debugging code defined within the notebook from the notebook file in VSCode (as opposed to having each cell be represented by a different non-existent file in VSCode as per current status).

To achieve this there is some complexity involved, as the package will internally create a dummy module in Main (called _NotebookModule_) and will evaluate in that dummy module all of the functions defined in the notebook (so that they can be defined with the corrects LineNumberNodes pointing to the notebook file)

This is thankfully made easy by the use of the ExpressionExplorer.jl package which was recently registered